### PR TITLE
fix: typo

### DIFF
--- a/docs/charge/how-to-create-cobv-using-api.mdx
+++ b/docs/charge/how-to-create-cobv-using-api.mdx
@@ -44,7 +44,7 @@ O body da sua requisição será semelhante a este exemplo:
 
 Após efetuar a requisição, se tudo ocorreu bem, o _status code_ da requisição será `2xx` e no `body` da resposta, retornaremos a assinatura criada.
 
-Retornarmeros a seguinte resposta de exemplo:
+Um resposta semelhante à seguinte será retornada:
 
 ```json
 {


### PR DESCRIPTION
Fix a typo on the content in the following link:

https://developers.woovi.com/docs/charge/how-to-create-cobv-using-api